### PR TITLE
Refactor config.c

### DIFF
--- a/src/compress.h
+++ b/src/compress.h
@@ -19,10 +19,10 @@
 
 #ifndef RS_COMPRESS_H
 #define RS_COMPRESS_H
+#include "config.h"
 #include "std.h"
 #include "util/buffer.h"
 #include "util/frame.h"
-#include "config.h"
 #include <jpeglib.h>
 
 typedef struct RSCompressDestination {

--- a/src/output.h
+++ b/src/output.h
@@ -19,14 +19,14 @@
 
 #ifndef RS_OUTPUT_H
 #define RS_OUTPUT_H
+#include "config.h"
 #include "std.h"
 #include "util/buffer.h"
 #include "util/circle.h"
-#include "config.h"
 #include <pthread.h>
 
 typedef struct RSOutput {
-   RSConfig config;
+   const RSConfig *config;
    FILE *file;
    RSBuffer frames;
    size_t frameCount;

--- a/src/std.h
+++ b/src/std.h
@@ -20,12 +20,12 @@
 #ifndef RS_STD_H
 #define RS_STD_H
 
-#include <stddef.h>
-#include <stdlib.h>
-#include <stdio.h>
 #include <stdarg.h>
-#include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #endif

--- a/src/util/path.c
+++ b/src/util/path.c
@@ -82,3 +82,14 @@ void rsPathAppendDated(RSBuffer *path, const char *value) {
       size *= 2;
    }
 }
+
+void rsPathFixHome(char* dst, const char* dir, const char* home) {
+	if (dir[0] == '~' && dir[1] == '/') {
+		strcat(dst, home);
+		strcat(dst, "/");
+		strcat(dst, dir+2);
+	}
+	else {
+		strcat(dst, dir);
+	}
+}

--- a/src/util/path.h
+++ b/src/util/path.h
@@ -25,5 +25,6 @@
 void rsPathClear(RSBuffer *path);
 void rsPathAppend(RSBuffer *path, const char *value);
 void rsPathAppendDated(RSBuffer *path, const char* value);
+void rsPathFixHome(char* dst, const char* dir, const char* home);
 
 #endif


### PR DESCRIPTION
Refactor of config.c

- fixed 2 memory leaks. Strings for pre/post commands weren't freed

- config file is read line by line instead of loading full file to a buffer. Lets us use standard C functions for getting a line instead of spliting manually on \n

- once a config file is parsed, search for more files is stoped. Config is simple enough where "overlays" seem pointless and might only confuse the user why his config is overwriten by some files he forgot about

- Program is now able to load files from ~/.config/. fopen will not be able to open a path that uses the "~~" symbol. $HOME has to be read

- strings with many paths separated by : are tokenized using more standard way

- all static ("private") functions are at the bottom of the file. That's just cosmetic and up to you how you like it.

Also a small change to the output.c / output.h

- config structure is no longer copied, only a pointer is stored. The structure was never modified by output.c functions, so I'm not sure why it was done so in the first place.