### PR TITLE
create-pkgbuild.sh: Clean up + follow guidelines

### DIFF
--- a/pkg/archlinux/create-pkgbuild.sh
+++ b/pkg/archlinux/create-pkgbuild.sh
@@ -3,7 +3,7 @@
 VERSION=$1
 
 if [ ! "${VERSION?}" ]; then
-   echo "Usage: create-pkgbuild.sh {version}"
+   echo 'Usage: create-pkgbuild.sh {version}'
    exit 1
 fi
 
@@ -11,30 +11,41 @@ cat <<- EOF
 pkgname=replay-sorcery
 pkgver=$VERSION
 pkgrel=1
-pkgdesc="An open-source, instant-replay screen recorder for Linux"
-arch=("i686" "x86_64")
-license=("GPL3")
-depends=("gcc-libs" "libxext")
-makedepends=("cmake" "make" "git" "nasm")
-url="https://github.com/matanui159/ReplaySorcery"
-source=("\${pkgname}::git+\${url}.git#tag=\${pkgver}")
-sha256sums=("SKIP")
+pkgdesc='An open-source, instant-replay screen recorder for Linux'
+arch=(i686 x86_64)
+license=(GPL3)
+depends=(gcc-libs libxext)
+makedepends=(cmake git nasm)
+url='https://github.com/matanui159/ReplaySorcery'
+source=("\${pkgname}"::git+"\${url}".git#tag="\${pkgver}"
+        git+https://github.com/libjpeg-turbo/libjpeg-turbo.git
+        git+https://github.com/ianlancetaylor/libbacktrace.git
+        git+https://code.videolan.org/videolan/x264.git
+        git+https://github.com/lieff/minimp4.git)
+sha256sums=('SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP'
+            'SKIP')
 
 prepare() {
-   mkdir -p "\${pkgname}/build"
-   git -C "\${pkgname}" submodule update --init --recursive --depth=1
+   cd \${pkgname}
+   git submodule init
+   git config submodule."dep/libjpeg-turbo".url ../libjpeg-turbo
+   git config submodule."dep/libbacktrace".url ../libbacktrace
+   git config submodule."dep/x264".url ../x264
+   git config submodule."dep/minimp4".url ../minimp4
+   git submodule update
 }
 
 build() {
-   cd "\${pkgname}" || exit 1
-   cmake -B build \\
+   cmake -B build -S "\${pkgname}" \\
       -DCMAKE_BUILD_TYPE=Release \\
       -DCMAKE_INSTALL_PREFIX=/usr
-   make -C build
+   cmake --build build
 }
 
 package() {
-   cd "\${pkgname}" || exit 1
-   make -C build DESTDIR=\${pkgdir} install
+   DESTDIR="\${pkgdir}" cmake --install build
 }
 EOF


### PR DESCRIPTION
Making separate commits for all this would be too much work and rather
silly so instead I am gonna list what I changed here:

* Removed makedepend that is already in base-devel
* Removed unneeded quote marks
* Replaced some quote marks with single quotes for safety
* Added all the submodules to the source array to comply with guidelines
  This also means the submodules can be cached and all downloading
  is handled by makepkg.
* Let cmake handle building and packaging since we're using that anyway
  and this seems to be the preferred way to do things, looking at other
  packages (like [extra]/spectacle)

What I did *not* add and namcap still complains about is that there is
still no maintainer set, but I do not know how to handle that with a
script like this.