### PR TITLE
Update README to remove outdated TODO item

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,4 @@ These options control the audio recording and its quallity. `audioDeviceName` ca
   - Maybe for Intel devices if they are fast enough?
 - Smaller tweaks:
   - Add sound effect for when it saves
-  - Add configuration option for changing hotkey
   - Allow downscaling before saving


### PR DESCRIPTION
The activation key can now be changed in the configuration file since faab136338f39ec5ca2447115e75ccbfeb07e9f5.