### PR TITLE
Use the High x264 profile for better bitrate efficiency

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -3,3 +3,4 @@
 - [Bennett Hardwick](https://github.com/bennetthardwick): AUR package scripts
 - [Magnus Boman](https://github.com/kattjevfel): AUR package scripts
 - [Patryk Seregiet](https://github.com/pseregiet): audio recording
+- [Hugo Locurcio](https://github.com/Calinou): video encoding options

--- a/src/output.c
+++ b/src/output.c
@@ -70,7 +70,7 @@ static void *outputThread(void *data) {
    x264_param_t params;
    x264_param_default(&params);
    x264_param_default_preset(&params, output->config->outputX264Preset, NULL);
-   x264_param_apply_profile(&params, "baseline");
+   x264_param_apply_profile(&params, "high");
    params.i_width = output->config->width;
    params.i_height = output->config->height;
    params.i_csp = X264_CSP_I420;


### PR DESCRIPTION
This results in smaller final encodes. Nearly all devices should support decoding H.264 files with the High profile nowadays. (In fact, the x264 examples seem to use the High profile.)