### PR TITLE
Add `outputX264Preset` option to control the output x264 preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ The key combo to use. Must be a series of modifiers followed by an X11 key name,
 ### `outputFile`
 The path to output the videos to. Can use [`strftime`](https://en.cppreference.com/w/c/chrono/strftime) formatting. If you care about folder organization it is probably a good idea to make ReplaySorcery output into a subfolder inside `Videos`, for example `~/Videos/ReplaySorcery/%F_%H-%M-%S.mp4`. This is not the default since currently ReplaySorcery cannot create folders and thus you have to make sure the folder exists before hand. Default is `~/Videos/ReplaySorcery_%F_%H-%M-%S.mp4`.
 
+### `outputX264Preset`
+The x264 preset value to use for encoding. Faster values will finish encoding the file faster, but with higher file sizes. To get smaller files with the same quality, you need to use a slower preset. `slower` is usually a good compromise if you want small files without having to wait too much. `placebo` is not recommended.
+
+Supported values (from least to most efficient) are `ultrafast`, `superfast`, `veryfast`, `faster`, `fast`, `medium`, `slow`, `slower`, `veryslow`, `placebo`. Default is `ultrafast`.
+
 ### `preOutputCommand` and `postOutputCommand`
 These options can be used to run commands before or after outputting a video, for instance generating notifications, playing sounds or running post processing. Failures from these commands do not stop ReplaySorcery. The default is setup to show a notification when the output is finished, but it requires `libnotify` to be installed. Default is an empty string and `notify-send ReplaySorcery "Video saved!"` respectively.
 

--- a/replay-sorcery.default.conf
+++ b/replay-sorcery.default.conf
@@ -24,6 +24,17 @@ keyCombo = Ctrl+Super+R
 # this is not the default since currently ReplaySorcery cannot create directories.
 outputFile = ~/Videos/ReplaySorcery_%F_%H-%M-%S.mp4
 
+# The x264 preset value to use for encoding. Faster values will finish encoding
+# the file faster, but with higher file sizes. To get smaller files with the
+# same quality, you need to use a slower preset. `slower` is usually a good
+# compromise if you want small files without having to wait too much.
+# `placebo` is not recommended.
+#
+# Supported values (from least to most efficient) are `ultrafast`, `superfast`,
+# `veryfast`, `faster`, `fast`, `medium`, `slow`, `slower`, `veryslow`,
+# `placebo`.
+outputX264Preset = ultrafast
+
 # These options can be used to run commands before or after outputting a video, for
 # instance generating notifications, playing sounds or running post processing.
 # preOutputCommand = notify-send ReplaySorcery "Saving video..."

--- a/src/config.c
+++ b/src/config.c
@@ -97,6 +97,7 @@ static const ConfigParam configParams[] = {
     CONFIG_PARAM(compressQuality, configPos, "70"),
     CONFIG_PARAM(keyCombo, configString, "Ctrl+Shift+R"),
     CONFIG_PARAM(outputFile, configString, "~/Videos/ReplaySorcery_%F_%H-%M-%S.mp4"),
+    CONFIG_PARAM(outputX264Preset, configString, "ultrafast"),
     CONFIG_PARAM(preOutputCommand, configString, ""),
     CONFIG_PARAM(postOutputCommand, configString,
                  "notify-send ReplaySorcery \"Video saved!\""),

--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,7 @@ typedef struct RSConfig {
    int compressQuality;
    char *keyCombo;
    char *outputFile;
+   char *outputX264Preset;
    char *preOutputCommand;
    char *postOutputCommand;
    char *audioDeviceName;

--- a/src/output.c
+++ b/src/output.c
@@ -69,7 +69,7 @@ static void *outputThread(void *data) {
 
    x264_param_t params;
    x264_param_default(&params);
-   x264_param_default_preset(&params, "ultrafast", NULL);
+   x264_param_default_preset(&params, output->config->outputX264Preset, NULL);
    x264_param_apply_profile(&params, "baseline");
    params.i_width = output->config->width;
    params.i_height = output->config->height;


### PR DESCRIPTION
Follow-up to #27.

A slower preset can be chosen to get smaller files with the same quality.