### PR TITLE
Fix odd resolutions in x264 encoder

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -71,7 +71,8 @@ static void *outputThread(void *data) {
    x264_param_default(&params);
    x264_param_default_preset(&params, output->config->outputX264Preset, NULL);
    x264_param_apply_profile(&params, "high");
-   params.i_width = (output->config->width / 2 ) * 2;
+   // The resolution has to be even for the encoder to work
+   params.i_width = (output->config->width / 2) * 2;
    params.i_height = (output->config->height / 2) * 2;
    params.i_csp = X264_CSP_I420;
    params.i_frame_total = (int)output->frameCount;

--- a/src/output.c
+++ b/src/output.c
@@ -71,8 +71,8 @@ static void *outputThread(void *data) {
    x264_param_default(&params);
    x264_param_default_preset(&params, output->config->outputX264Preset, NULL);
    x264_param_apply_profile(&params, "high");
-   params.i_width = output->config->width;
-   params.i_height = output->config->height;
+   params.i_width = (output->config->width / 2 ) * 2;
+   params.i_height = (output->config->height / 2) * 2;
    params.i_csp = X264_CSP_I420;
    params.i_frame_total = (int)output->frameCount;
    params.i_timebase_num = 1;


### PR DESCRIPTION
Fix odd resolutions crashing the encoder (usually from multiple monitors).
Example:
```
x264 [error]: width not divisible by 2 (3839x1080)
Signal error: Segment violation
```