### PR TITLE
Added mention of maintained packages for Solus

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ There is an official AUR package that gets updated from the CI (thanks to [Benne
 
 [Sergey A.](https://github.com/murlakatamenka) has also setup a `-git` AUR package: [replay-sorcery-git](https://aur.archlinux.org/packages/replay-sorcery-git).
 
+### Solus
+ReplaySorcery is packaged by the official distribution maintainers in their main repo.(thanks to [Joshua Strobl](https://github.com/JoshStrobl)): [replaysorcery](https://dev.getsol.us/source/replaysorcery)
+`sudo eopkg it replaysorcery`
+*Debug symbols for ReplaySorcery are also packaged, as replaysorcery-dbginfo*
+
+
 ## Building from Source
 ```
 $ git submodule update --init


### PR DESCRIPTION
Mentioning the maintainer if you have some questions about the package, outside of contacting them via the dev.getsol.us git. https://github.com/JoshStrobl
To be honest, the package worked better than the AUR replay-sorcery one. Better defaults? Distribution compatibility? Either way, I can confirm it works beautifully.